### PR TITLE
`HomogeneousPoissonProcess` type

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -84,6 +84,12 @@ fit_map
 AbstractPoissonProcess
 ```
 
+### Homogeneous
+
+```@docs
+HomogeneousPoissonProcess
+```
+
 ### Multivariate
 
 ```@docs

--- a/src/PointProcesses.jl
+++ b/src/PointProcesses.jl
@@ -46,6 +46,7 @@ export simulate_ogata, simulate
 ## Models
 
 export AbstractPoissonProcess
+export HomogeneousPoissonProcess
 export MultivariatePoissonProcess, MultivariatePoissonProcessPrior
 export MarkedPoissonProcess
 export HawkesProcess
@@ -59,6 +60,8 @@ include("bounded_point_process.jl")
 
 include("poisson/abstract_poisson_process.jl")
 include("poisson/simulation.jl")
+
+include("poisson/homogeneous/homogeneous_poisson_process.jl")
 
 include("poisson/multivariate/multivariate_poisson_process.jl")
 include("poisson/multivariate/suffstats.jl")

--- a/src/history.jl
+++ b/src/history.jl
@@ -59,6 +59,13 @@ function Base.show(io::IO, h::History{T,M}) where {T,M}
     )
 end
 
+function Base.:(==)(h1::History, h2::History)
+    equal_times = h1.times == h2.times
+    equal_marks = h1.marks == h2.marks
+    equal_interval = (h1.tmin == h2.tmin) && (h1.tmax == h2.tmax)
+    return equal_times && equal_marks && equal_interval
+end
+
 """
     event_times(h)
 

--- a/src/poisson/homogeneous/homogeneous_poisson_process.jl
+++ b/src/poisson/homogeneous/homogeneous_poisson_process.jl
@@ -1,0 +1,52 @@
+"""
+    HomogeneousPoissonProcess{T<:Real}
+
+Univariate Temporal Poisson process
+
+# Fields
+- `μ::T`: event rate
+"""
+struct HomogeneousPoissonProcess{T<:Real} <: AbstractPoissonProcess
+    λ::T
+
+    function HomogeneousPoissonProcess(λ::Real)
+        if λ < 0
+            throw(DomainError(λ, "Event rate λ must be positive."))
+        end
+        new{typeof(λ)}(λ)
+    end
+end
+
+function simulate(rng::AbstractRNG, pp::HomogeneousPoissonProcess, tmin::Real, tmax::Real)
+    times = simulate_poisson_times(rng, pp.λ, tmin, tmax)
+    return History(; times=times, tmin=tmin, tmax=tmax, check=false)
+end
+
+function simulate(pp::HomogeneousPoissonProcess, tmin::Real, tmax::Real)
+    return simulate(default_rng(), pp, tmin, tmax)
+end
+"""
+    StatsAPI.fit(rng, ::Type{HomogeneousPoissonProcess}, h::History)
+
+Estimates the parameters of a homogeneous Poisson process from event history `h`
+"""
+function StatsAPI.fit(::Type{HomogeneousPoissonProcess{T}}, h::History) where {T<:Real}
+    return HomogeneousPoissonProcess(T(nb_events(h) / duration(h)))
+end
+
+# Type parameter for `HomogeneousPoissonProcess` was NOT explicitly provided
+function StatsAPI.fit(
+    HP::Type{HomogeneousPoissonProcess}, h::History{H,M}
+) where {H<:Real,M}
+    T = promote_type(Float64, H)
+    return fit(HP{T}, h)
+end
+
+function time_change(pp::HomogeneousPoissonProcess, h::History)
+    times = (h.times .- h.tmin) * pp.λ
+    tmax = duration(h) * pp.λ
+    return History(; times=times, marks=h.marks, tmin=0, tmax=tmax, check=false)
+end
+
+ground_intensity(pp::HomogeneousPoissonProcess) = pp.λ
+intensity(pp::HomogeneousPoissonProcess) = ground_intensity(pp)

--- a/test/homogeneous_poisson_process.jl
+++ b/test/homogeneous_poisson_process.jl
@@ -1,0 +1,26 @@
+# Instantiation
+@test_throws DomainError HomogeneousPoissonProcess(-1)
+
+pp = HomogeneousPoissonProcess(1)
+
+@test string(pp) == "HomogeneousPoissonProcess{Int64}(1)"
+
+# Simulation
+@test simulate(pp, 0, 10) isa History{Float64,Nothing}
+@test simulate(Random.seed!(1), pp, BigFloat(0), 10) isa History{BigFloat,Nothing}
+
+# Fit
+h = History(rand(10), 0, 1)
+pp_fit = fit(HomogeneousPoissonProcess, h)
+
+@test pp_fit.λ ≈ 10
+@test pp_fit isa HomogeneousPoissonProcess{Float64}
+@test fit(HomogeneousPoissonProcess{BigFloat}, h) isa HomogeneousPoissonProcess{BigFloat}
+
+# Time change
+@test time_change(pp, h) == h
+@test all(time_change(pp_fit, h).times .≈ h.times .* 10)
+
+# Intensity
+@test ground_intensity(pp_fit) == 10
+@test intensity(pp_fit) == 10

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,9 @@ DocMeta.setdocmeta!(PointProcesses, :DocTestSetup, :(using PointProcesses); recu
         include("bounded_point_process.jl")
     end
     @testset verbose = true "Poisson" begin
+        @testset verbose = true "Homogeneous" begin
+            include("homogeneous_poisson_process.jl")
+        end
         @testset verbose = true "Multivariate" begin
             include("multivariate_poisson_process.jl")
         end


### PR DESCRIPTION
Although it would be possible to use either `MarkedPoissonProcess` or `MultivariatePoissonProcess` to emulate a homogeneous Poisson process, it would be a bit awkward and very unintuitive. Since this is the basic process, I guess this should have its own type and be convenient to use.

Having this will also make it easier to implement tests for the goodness-of-fit tests in PR #60.